### PR TITLE
Automate the creation of Argo CD applications

### DIFF
--- a/argocd-plugin/argocd-cm-patch.yaml
+++ b/argocd-plugin/argocd-cm-patch.yaml
@@ -4,6 +4,10 @@ data:
       generate:
         command: ["/bin/bash", "-c"]
         args: ["wrap4kyst && kustomize build ."]
+    - name: wrap4kyst-scalability
+      generate:
+        command: ["/bin/bash", "-c"]
+        args: ["wrap4kyst --unique-configspec-name=true && kustomize build ."]
     - name: wrap4kyst-ocm
       generate:
         command: ["/bin/bash", "-c"]

--- a/argocd-plugin/wrap4kyst/main.go
+++ b/argocd-plugin/wrap4kyst/main.go
@@ -17,6 +17,7 @@ func main() {
 	configSpecFN := flag.String("configspec", "./configspec.yaml", "the configspec file with content populated")
 	manifestDir := flag.String("manifest-dir", "../manifests/", "the directory containing the to-be-wrapped manifests")
 	extraManifestDir := flag.String("extra-manifest-dir", "./extra-manifests/", "the directory containing target-specific manifests (Custom Resources)")
+	uniqueConfigSpecName := flag.Bool("unique-configspec-name", false, "make the output configspec name unique, used for scalability experiments only")
 	flag.Parse()
 
 	if *target != "k8s" && *target != "ocm" && *target != "flotta" {
@@ -45,6 +46,10 @@ func main() {
 		content = append(content, string(item))
 	}
 	configSpec["spec"].(map[string]interface{})["content"] = content
+
+	if *uniqueConfigSpecName {
+		configSpec = util.AppendTimestampToConfigSpecName(configSpec)
+	}
 
 	err = util.WriteConfigSpec(*configSpecFN, configSpec)
 	if err != nil {

--- a/argocd-plugin/wrap4kyst/util/configspec.go
+++ b/argocd-plugin/wrap4kyst/util/configspec.go
@@ -3,6 +3,8 @@ package util
 import (
 	"io/ioutil"
 	"log"
+	"strconv"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -48,4 +50,16 @@ func ComposeRawContent(dir string) [][]byte {
 		}
 	}
 	return rawContent
+}
+
+func appendTimestamp(prefix string) string {
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 10)
+	return prefix + "-" + suffix
+}
+
+func AppendTimestampToConfigSpecName(configSpec map[string]interface{}) map[string]interface{} {
+	name := configSpec["metadata"].(map[string]interface{})["name"].(string)
+	name = appendTimestamp(name)
+	configSpec["metadata"].(map[string]interface{})["name"] = name
+	return configSpec
 }

--- a/argocd-scalability/README.md
+++ b/argocd-scalability/README.md
@@ -21,6 +21,8 @@ Here is an example:
 kubectl -n argocd apply -f argocd-scalability/applicationset.yaml
 ```
 
+### Create Argo CD applications using Cluster Loader
+
 ### Sync an Argo CD application using local directory
 ```shell
 argocd app sync argocd-scalability-00001 --local ./examples/kubernetes/nginx/deploy-flotta/

--- a/argocd-scalability/README.md
+++ b/argocd-scalability/README.md
@@ -1,6 +1,6 @@
-### Argo CD Scalability Experiment
+## Argo CD Scalability Experiment
 
-#### Manually create an Argo CD application
+### Create an Argo CD application from command line
 For example:
 ```shell
 argocd app create argocd-scalability-00001 \
@@ -11,25 +11,29 @@ argocd app create argocd-scalability-00001 \
 --dest-namespace argocd-scalability
 ```
 
-#### Automation using Argo CD ApplicationSet
+### Create Argo CD applications using ApplicationSet
 Argo CD's [ApplicationSet](https://argo-cd.readthedocs.io/en/stable/user-guide/application-set/) controller can automate the creation of multiple Argo CD applications, using 'generators' and 'templates'.
 
 There are [various generators](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators/) provided by Argo.
 Looks like the [Git Generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Git/) fits into our use case.
+Here is an example:
+```shell
+kubectl -n argocd apply -f argocd-scalability/applicationset.yaml
+```
 
-#### Sync an Argo CD application using local directory
+### Sync an Argo CD application using local directory
 ```shell
 argocd app sync argocd-scalability-00001 --local ./examples/kubernetes/nginx/deploy-flotta/
 ```
 
-##### Prerequisites
+#### Prerequisites
 - `kustomize` installed if using `--local` option for `argocd app sync`.
 - `wrap4kyst` binary in `PATH` if using the `wrap4kyst` plugin and using the `--local` option for `argocd app sync`. The binary can be made available by compliling the `wrap4kyst` plugin locally, or by copying a complied one from a container:
 ```shell
 docker cp 23058b2b81fb:/wrap4kyst .
 ```
 
-#### Questions
+### Questions
 - Telemetry?
 - (Pure) configurations v.s. workloads?
 - Apps v.s. clusters?

--- a/argocd-scalability/README.md
+++ b/argocd-scalability/README.md
@@ -3,7 +3,7 @@
 #### Manually create an Argo CD application
 For example:
 ```shell
-argocd app create argocd-scalability-0001 \
+argocd app create argocd-scalability-00001 \
 --config-management-plugin wrap4kyst-flotta \
 --repo https://github.com/edge-experiments/kyst-configurations.git \
 --path examples/kubernetes/nginx/deploy-flotta \
@@ -19,7 +19,7 @@ Looks like the [Git Generator](https://argo-cd.readthedocs.io/en/stable/operator
 
 #### Sync an Argo CD application using local directory
 ```shell
-argocd app sync argocd-scalability-0001 --local ./examples/kubernetes/nginx/deploy-flotta/
+argocd app sync argocd-scalability-00001 --local ./examples/kubernetes/nginx/deploy-flotta/
 ```
 
 ##### Prerequisites
@@ -32,3 +32,4 @@ docker cp 23058b2b81fb:/wrap4kyst .
 #### Questions
 - Telemetry?
 - (Pure) configurations v.s. workloads?
+- Apps v.s. clusters?

--- a/argocd-scalability/README.md
+++ b/argocd-scalability/README.md
@@ -22,6 +22,11 @@ kubectl -n argocd apply -f argocd-scalability/applicationset.yaml
 ```
 
 ### Create Argo CD applications using Cluster Loader
+[Cluster Loader](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2) can automate the creation of multiple Argo CD applications, because an Argo CD application is a Kubernetes Custom Resource.
+
+However, a little hack is necessary to make it work. The intial trial failed, because Cluster Loader today only allows objects to be created in its managed (meaning created at runtime with randomized names) namespaces. But Argo CD only recogonizes Applications in `argocd` namespace. We can hack Cluster Loader's [code](https://github.com/kubernetes/perf-tests/blob/8a0c339a42a6f0419a10fd3a701a8284c37511f3/clusterloader2/pkg/test/simple_test_executor.go#L181) as a work around. More discussions available [here](https://kubernetes.slack.com/archives/C09QZTRH7/p1657089711061019).
+
+We also need the `unique-configspec-name` option for the `wrap4kyst` plugin. Using this option, even multiple Argo CD applications are created with one single set of files in git, the output ConfigSpecs are still unique. Therefore, the multiple Argo CD applications won't conflict with each other. With this option, we eliminate the need of creating a separate set of files for each Argo CD application.
 
 ### Sync an Argo CD application using local directory
 ```shell
@@ -37,5 +42,4 @@ docker cp 23058b2b81fb:/wrap4kyst .
 
 ### Questions
 - Telemetry?
-- (Pure) configurations v.s. workloads?
 - Apps v.s. clusters?

--- a/argocd-scalability/applicationset.yaml
+++ b/argocd-scalability/applicationset.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: argocd-scalability
+  namespace: argocd
+spec:
+  generators:
+  - git:
+      repoURL: https://github.com/edge-experiments/kyst-configurations.git
+      revision: argocd-scalability
+      directories:
+      - path: argocd-scalability/git-generator-directory/*
+  template:
+    metadata:
+      name: '{{path[0]}}'
+    spec:
+      project: "argocd-scalability"
+      source:
+        repoURL: https://github.com/argoproj/argo-cd.git
+        targetRevision: argocd-scalability
+        path: '{{path}}/deploy/'
+      destination:
+        server: https://13.56.252.125:6443
+        namespace: argocd-scalability

--- a/argocd-scalability/applicationset.yaml
+++ b/argocd-scalability/applicationset.yaml
@@ -12,13 +12,15 @@ spec:
       - path: argocd-scalability/git-generator-directory/*
   template:
     metadata:
-      name: '{{path[0]}}'
+      name: 'argocd-scalability-{{path.basename}}'
     spec:
-      project: "argocd-scalability"
+      project: default
       source:
-        repoURL: https://github.com/argoproj/argo-cd.git
+        repoURL: https://github.com/edge-experiments/kyst-configurations.git
         targetRevision: argocd-scalability
         path: '{{path}}/deploy/'
+        plugin:
+          name: wrap4kyst-ocm
       destination:
         server: https://13.56.252.125:6443
         namespace: argocd-scalability

--- a/argocd-scalability/applicationset.yaml
+++ b/argocd-scalability/applicationset.yaml
@@ -20,7 +20,7 @@ spec:
         targetRevision: argocd-scalability
         path: '{{path}}/deploy/'
         plugin:
-          name: wrap4kyst-ocm
+          name: wrap4kyst
       destination:
         server: https://13.56.252.125:6443
         namespace: argocd-scalability

--- a/argocd-scalability/clusterloader-manifests/config.yaml
+++ b/argocd-scalability/clusterloader-manifests/config.yaml
@@ -1,0 +1,53 @@
+name: test
+
+namespace:
+  number: 1
+
+tuningSets:
+- name: Uniform
+  qpsLoad:
+    qps: 0.1
+- name: Random
+  randomizedLoad:
+    averageQps: 0.5
+
+steps:
+# - name: Start measurements
+#   measurements:
+#   - Identifier: PodStartupLatency
+#     Method: PodStartupLatency
+#     Params:
+#       action: start
+#       labelSelector: group = test-pod
+#       threshold: 20s
+#   - Identifier: WaitForControlledPodsRunning
+#     Method: WaitForControlledPodsRunning
+#     Params:
+#       action: start
+#       apiVersion: apps/v1
+#       kind: Deployment
+#       labelSelector: group = test-deployment
+#       operationTimeout: 120s
+- name: Create application
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 3 # maximum that my edgeclusters can bear
+    tuningSet: Random
+    objectBundle:
+    - basename: test-application
+      objectTemplatePath: "test-application.yaml"
+      templateFillMap: {}
+# - name: Wait for pods to be running
+#   measurements:
+#   - Identifier: WaitForControlledPodsRunning
+#     Method: WaitForControlledPodsRunning
+#     Params:
+#       action: gather
+# - name: Measure pod startup latency
+#   measurements:
+#   - Identifier: PodStartupLatency
+#     Method: PodStartupLatency
+#     Params:
+#       action: gather

--- a/argocd-scalability/clusterloader-manifests/test-application.yaml
+++ b/argocd-scalability/clusterloader-manifests/test-application.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{.Name}}
+spec:
+  destination:
+    namespace: argocd-scalability
+    server: https://13.56.252.125:6443
+  project: default
+  source:
+    path: examples/kubernetes/guestbook/deploy-scalability/
+    plugin:
+      name: wrap4kyst-scalability
+    repoURL: https://github.com/edge-experiments/kyst-configurations.git
+    targetRevision: argocd-scalability

--- a/argocd-scalability/git-generator-directory/00001/deploy/configspec-empty.yaml
+++ b/argocd-scalability/git-generator-directory/00001/deploy/configspec-empty.yaml
@@ -1,0 +1,7 @@
+apiVersion: edge.kyst.kube/v1alpha1
+kind: ConfigSpec
+metadata:
+  # edit the name here
+  name: guestbook-00001
+spec:
+  content: []

--- a/argocd-scalability/git-generator-directory/00001/deploy/devicegroup.yaml
+++ b/argocd-scalability/git-generator-directory/00001/deploy/devicegroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: edge.kyst.kube/v1alpha1
+kind: DeviceGroup
+metadata:
+  # edit the name here
+  name: guestbook-00001
+spec:
+  configSpecName: guestbook-00001

--- a/argocd-scalability/git-generator-directory/00001/deploy/kustomization.yaml
+++ b/argocd-scalability/git-generator-directory/00001/deploy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- configspec.yaml
+- devicegroup.yaml

--- a/argocd-scalability/git-generator-directory/00001/manifests/guestbook-ui-deployment.yaml
+++ b/argocd-scalability/git-generator-directory/00001/manifests/guestbook-ui-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: guestbook-ui
+  namespace: default
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: guestbook-ui
+  template:
+    metadata:
+      labels:
+        app: guestbook-ui
+    spec:
+      containers:
+      - image: gcr.io/heptio-images/ks-guestbook-demo:0.2
+        name: guestbook-ui
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi

--- a/argocd-scalability/git-generator-directory/00001/manifests/guestbook-ui-svc.yaml
+++ b/argocd-scalability/git-generator-directory/00001/manifests/guestbook-ui-svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: guestbook-ui
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: guestbook-ui

--- a/argocd-scalability/git-generator-directory/00002/deploy/configspec-empty.yaml
+++ b/argocd-scalability/git-generator-directory/00002/deploy/configspec-empty.yaml
@@ -1,0 +1,7 @@
+apiVersion: edge.kyst.kube/v1alpha1
+kind: ConfigSpec
+metadata:
+  # edit the name here
+  name: guestbook-00002
+spec:
+  content: []

--- a/argocd-scalability/git-generator-directory/00002/deploy/devicegroup.yaml
+++ b/argocd-scalability/git-generator-directory/00002/deploy/devicegroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: edge.kyst.kube/v1alpha1
+kind: DeviceGroup
+metadata:
+  # edit the name here
+  name: guestbook-00002
+spec:
+  configSpecName: guestbook-00002

--- a/argocd-scalability/git-generator-directory/00002/deploy/kustomization.yaml
+++ b/argocd-scalability/git-generator-directory/00002/deploy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- configspec.yaml
+- devicegroup.yaml

--- a/argocd-scalability/git-generator-directory/00002/manifests/guestbook-ui-deployment.yaml
+++ b/argocd-scalability/git-generator-directory/00002/manifests/guestbook-ui-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: guestbook-ui
+  namespace: default
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: guestbook-ui
+  template:
+    metadata:
+      labels:
+        app: guestbook-ui
+    spec:
+      containers:
+      - image: gcr.io/heptio-images/ks-guestbook-demo:0.2
+        name: guestbook-ui
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi

--- a/argocd-scalability/git-generator-directory/00002/manifests/guestbook-ui-svc.yaml
+++ b/argocd-scalability/git-generator-directory/00002/manifests/guestbook-ui-svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: guestbook-ui
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+  selector:
+    app: guestbook-ui

--- a/examples/kubernetes/guestbook/deploy-scalability/configspec-empty.yaml
+++ b/examples/kubernetes/guestbook/deploy-scalability/configspec-empty.yaml
@@ -1,0 +1,7 @@
+apiVersion: edge.kyst.kube/v1alpha1
+kind: ConfigSpec
+metadata:
+  # edit the name here
+  name: guestbook
+spec:
+  content: []

--- a/examples/kubernetes/guestbook/deploy-scalability/kustomization.yaml
+++ b/examples/kubernetes/guestbook/deploy-scalability/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- configspec.yaml


### PR DESCRIPTION
We need to automate the creation of Argo CD applications for our Argo CD scalability experiments.

We currently have two ways to automate this:
1. use Argo CD's ApplicationSet API;
2. use Cluster Loader, with some small tweaks.
