### PR TITLE
Setting up telemetry for Argo CD

### DIFF
--- a/argocd-scalability/clusterloader-manifests/config.yaml
+++ b/argocd-scalability/clusterloader-manifests/config.yaml
@@ -9,7 +9,7 @@ tuningSets:
     qps: 0.1
 - name: Random
   randomizedLoad:
-    averageQps: 0.5
+    averageQps: 1
 
 steps:
 # - name: Start measurements
@@ -33,7 +33,7 @@ steps:
   - namespaceRange:
       min: 1
       max: 1
-    replicasPerNamespace: 100
+    replicasPerNamespace: 1000
     tuningSet: Random
     objectBundle:
     - basename: test-application

--- a/argocd-scalability/clusterloader-manifests/config.yaml
+++ b/argocd-scalability/clusterloader-manifests/config.yaml
@@ -33,7 +33,7 @@ steps:
   - namespaceRange:
       min: 1
       max: 1
-    replicasPerNamespace: 3 # maximum that my edgeclusters can bear
+    replicasPerNamespace: 100
     tuningSet: Random
     objectBundle:
     - basename: test-application

--- a/argocd-scalability/clusterloader-manifests/test-application.yaml
+++ b/argocd-scalability/clusterloader-manifests/test-application.yaml
@@ -13,3 +13,6 @@ spec:
       name: wrap4kyst-scalability
     repoURL: https://github.com/edge-experiments/kyst-configurations.git
     targetRevision: argocd-scalability
+  syncPolicy:
+    automated:
+      prune: true

--- a/argocd-scalability/monitoring/rbac.yaml
+++ b/argocd-scalability/monitoring/rbac.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: argocd
+  name: prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: argocd
+  name: prometheus-k8s
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-k8s-views-all
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring

--- a/argocd-scalability/monitoring/service-monitors.yaml
+++ b/argocd-scalability/monitoring/service-monitors.yaml
@@ -1,0 +1,41 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argocd-metrics
+  namespace: argocd
+  labels:
+    release: prometheus-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-metrics
+  endpoints:
+  - port: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argocd-server-metrics
+  namespace: argocd
+  labels:
+    release: prometheus-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-server-metrics
+  endpoints:
+  - port: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argocd-repo-server-metrics
+  namespace: argocd
+  labels:
+    release: prometheus-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-repo-server
+  endpoints:
+  - port: metrics


### PR DESCRIPTION
This PR sets up basic monitoring to get more visibility for Argo CD scalability experiments.
